### PR TITLE
Add sideloadly tutorial for adding satellajailed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,21 @@ Now you can make fake purchases without a jailbreak! Just attempt a purchase and
 
 [1]:	https://github.com/Paisseon/Satella2
 [2]:	https://appdb.to/?ref=cb9904cc802fa5380a7aa4c35fe0d0c1
+
+## Sideloadly method
+
+1. Download the latest version of Sideloadly for Windows or MacOS from [here](https://sideloadly.io/#:~:text=download%20link.-,Download%20Sideloadly,-Windows%2064%2Dbit)
+2. Download the decrypted IPA you want to add the SatellaJailed tweak from [here](https://armconverter.com/decryptedappstore/) **(to download from armconverter you need to have a iOSGods account, if you do not have a iOSGods account, you can download the IPA from appdb)**
+3. Once you have the decrypted IPA you want to add SatellaJailed to, download SatellaJailed from the recent [releases](https://github.com/Aholicknight/SatellaJailed/releases/tag/satella-jailed.dylib) 
+---
+### Sideloadly: Windows 
+1. Before starting, make sure you sign in with your AppleID, once you have signed into your AppleID, your connected iPhone will show up in the iDevice tab. Make sure you also have "Advanced options" enabled.
+* ![sideloadly1](https://user-images.githubusercontent.com/7843719/173176702-17ef8679-e467-4bbe-8f5f-f7381a3ca7f2.png)
+2. Drag and drop the IPA you downloaded from armconverter, appdb, or any other site. **make sure the IPA file ends in .ipa** 
+* ![sideloadlyvideotut](https://user-images.githubusercontent.com/7843719/173177755-487eea8a-db93-418a-b21b-c93a5165c722.gif)
+3. Checkmark "Inject dylibs/frameworks" at the bottom of "Advanced options". Once "inject dylibs/frameworks" is checkmarked, drag Satella-jailed.dylib into the white box. If you can't drag the file, you can also click the button "+dylib/deb" 
+* ![sideloadly2](https://user-images.githubusercontent.com/7843719/173177914-a2da842a-9639-4a53-9380-20f9da5698d6.png)
+4. Once you have the IPA you want to add satella-jailed + the tweak satella-jailed applied in "Inject dylibs/frameworks" press the start button on the bottom of sideloadly and wait for the install to complete. 
+---
+### Sideloadly: macOS
+1. Basically the same steps as Windows, just in a macOS environment. 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Now you can make fake purchases without a jailbreak! Just attempt a purchase and
 
 1. Download the latest version of Sideloadly for Windows or MacOS from [here](https://sideloadly.io/#:~:text=download%20link.-,Download%20Sideloadly,-Windows%2064%2Dbit)
 2. Download the decrypted IPA you want to add the SatellaJailed tweak from [here](https://armconverter.com/decryptedappstore/) **(to download from armconverter you need to have a iOSGods account, if you do not have a iOSGods account, you can download the IPA from appdb)**
-3. Once you have the decrypted IPA you want to add SatellaJailed to, download SatellaJailed from the recent [releases](https://github.com/Aholicknight/SatellaJailed/releases/tag/satella-jailed.dylib) 
+3. Once you have the decrypted IPA you want to add SatellaJailed to, download SatellaJailed from the recent [releases](https://github.com/Aholicknight/SatellaJailed/releases/tag/Satellajailed-dylib) 
 ---
 ### Sideloadly: Windows 
 1. Before starting, make sure you sign in with your AppleID, once you have signed into your AppleID, your connected iPhone will show up in the iDevice tab. Make sure you also have "Advanced options" enabled.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Now you can make fake purchases without a jailbreak! Just attempt a purchase and
 1. Download the latest version of Sideloadly for Windows or MacOS from [here](https://sideloadly.io/#:~:text=download%20link.-,Download%20Sideloadly,-Windows%2064%2Dbit)
 2. Download the decrypted IPA you want to add the SatellaJailed tweak from [here](https://armconverter.com/decryptedappstore/) **(to download from armconverter you need to have a iOSGods account, if you do not have a iOSGods account, you can download the IPA from appdb)**
 3. Once you have the decrypted IPA you want to add SatellaJailed to, download SatellaJailed from the recent [releases](https://github.com/Aholicknight/SatellaJailed/releases/tag/Satellajailed-dylib) 
+
+**IMPORTANT: Make sure you know your current iOS version before doing this. To make sure that crashes do not happen when you add Satella Jailed to your IPA, you also need to add the Orion Framework which depends on your iOS version**
+* If you are using ***iOS 12 to 13*** download [Orion_12-13.zip](https://github.com/Paisseon/SatellaJailed/raw/emt/Orion_12-13.zip) 
+* If you are using ***iOS 14 to 15***, and newer versions, download [Orion_14-15](https://github.com/Paisseon/SatellaJailed/raw/emt/Orion_14-15.zip)
+
+Once you have Orion Framework downloaded you can continue with the tutorial.
+
 ---
 ### Sideloadly: Windows 
 1. Before starting, make sure you sign in with your AppleID, once you have signed into your AppleID, your connected iPhone will show up in the iDevice tab. Make sure you also have "Advanced options" enabled.
@@ -35,7 +42,9 @@ Now you can make fake purchases without a jailbreak! Just attempt a purchase and
 * ![sideloadlyvideotut](https://user-images.githubusercontent.com/7843719/173177755-487eea8a-db93-418a-b21b-c93a5165c722.gif)
 3. Checkmark "Inject dylibs/frameworks" at the bottom of "Advanced options". Once "inject dylibs/frameworks" is checkmarked, drag Satella-jailed.dylib into the white box. If you can't drag the file, you can also click the button "+dylib/deb" 
 * ![sideloadly2](https://user-images.githubusercontent.com/7843719/173177914-a2da842a-9639-4a53-9380-20f9da5698d6.png)
-4. Once you have the IPA you want to add satella-jailed + the tweak satella-jailed applied in "Inject dylibs/frameworks" press the start button on the bottom of sideloadly and wait for the install to complete. 
+4. Once you have the IPA you want to add satella-jailed + the tweak satella-jailed applied in "Inject dylibs/frameworks"
+5. Once satella-jailed is added, extract the Orion Framework zip you previously downloaded for your iOS version and load the `Orion.framework` folder into sideloadly with the `+framework/bundle` button.
+6. Press the start button on the bottom of sideloadly and wait for the install to complete. 
 ---
 ### Sideloadly: macOS
 1. Basically the same steps as Windows, just in a macOS environment. 


### PR DESCRIPTION
Added a sideloadly tutorial for adding satellajailed to decrypted IPA's. For this to work with sideloadly, I have added the satella-jailed.dylib to my [releases fork](https://github.com/Aholicknight/SatellaJailed/releases/tag/satella-jailed.dylib) 