### PR TITLE
Add colored output to the patch script

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -1,8 +1,20 @@
 #!/bin/sh
 # Made by Paisseon and Sudo
 
+# Fancy colors
+reset="\e[0m"
+faint="\e[2m"
+red="\e[31m"
+black="\e[30m"
+green="\e[32m"
+yellow="\e[33m"
+
+info="${black}${faint}[${reset}${green}*${reset}${black}${faint}]${reset}"
+error="${black}${faint}[${reset}${red}!${reset}${black}${faint}]${reset}"
+warn="${black}${faint}[${reset}${yellow}!${reset}${black}${faint}]$reset}"
+
 println() {
-    printf '%s\n' "$*"
+    echo -e "$*"
 }
 
 # Read arguments. If you're not me, ignore the -x flag
@@ -10,28 +22,28 @@ println() {
 while getopts ":v:i:o:xy" args; do
     case "${args}" in
         v)
-            println "[*] The -v flag no longer does anything"
+            println "$warn The -v flag no longer does anything"
             ;;
         i)
-            println "[*] Setting input file as ${OPTARG}"
+            println "$info Setting input file as ${OPTARG}"
             ipa="${OPTARG}"
             ;;
         o)
-            println "[*] Setting output file as ${OPTARG}"
+            println "$info Setting output file as ${OPTARG}"
             output="${OPTARG}"
             ;;
         x)
-            println "[*] Set to transfer file to iPad after patching"
+            println "$info Set to transfer file to iPad after patching"
             transfer=true
             device=0
             ;;
         y)
-            println "[*] Set to transfer file to iPhone after patching"
+            println "$info Set to transfer file to iPhone after patching"
             transfer=true
             device=1
             ;;
         *)
-            println "[*] Error: Invalid argument: ${OPTARG}. Satella Jailed patcher accepts only -i, and -o arguments"
+            println "$error Invalid argument: ${OPTARG}. Satella Jailed patcher accepts only -i, and -o arguments"
             exit
             ;;
     esac
@@ -40,7 +52,7 @@ done
 # Say to install Azule if it doesn't exist already
 
 if [ ! -f "$(which azule)" ]; then
-    println "[*] Please install Azule from https://github.com/Al4ise/Azule/wiki to continue"
+    println "$error Please install Azule from https://github.com/Al4ise/Azule/wiki to continue"
     exit
 fi
 
@@ -67,7 +79,7 @@ fi
 # Exit if the $ipa variable is not set
 
 if [ -z "$ipa" ]; then
-    println "[*] Error: Couldn't find .ipa file"
+    println "$error Couldn't find .ipa file"
     exit
 fi
 
@@ -79,24 +91,22 @@ fi
 
 # Log for debug purposes
 
-println "[*] Input: $ipa"
-println "[*] Output: $output.ipa"
+println "$info Input: $ipa"
+println "$info Output: $output.ipa"
 
 # Inject SatellaJailed to the app using Azule
-
-azule -n "$output" -i "$ipa" -o ./ -f ./SatellaJailed.dylib -muvw
+azule -n "$output" -i "$ipa" -o ./ -f ./SatellaJailed.dylib -muvw | sed -u -r "s/(\[\*\])/$(println $info)/g"
 
 # Transfer to device if the -x flag is enabled
-
 if [ $transfer ]; then
     if [ -f /usr/local/bin/xenon ]; then
-        println "[*] Transferring to device"
+        println "$info Transferring to device"
         xenon "$output.ipa" "$device"
     else
-        println "[*] Transfer not initiated as xenon doesn't exist"
+        println "$warn Transfer not initiated as xenon isn't installed."
     fi
 fi
 
 # Finish up
 
-println "[*] Done!"
+println "$info Done!"


### PR DESCRIPTION
This commit colorizes the output of the patch script, making it more visually appealing. Not really "important," but still nice to have.

See the newly colorized output below:
<img width="682" alt="image" src="https://user-images.githubusercontent.com/37126748/203466288-9c725545-b0fc-45af-ba1e-432f36e68a1f.png">
